### PR TITLE
New top-level domains

### DIFF
--- a/Objects/WebView.lua
+++ b/Objects/WebView.lua
@@ -162,7 +162,7 @@ GoToURL = function(self, url, nonVerbose, noHistory, post)
 
 	-- TODO: 404s are counted as downloads
 
-	if not extension or (extension ~= true and extension ~= '' and extension ~= 'ccml' and extension ~= 'html' and extension ~= 'php' and extension ~= 'asp' and extension ~= 'aspx' and extension ~= 'jsp' and extension ~= 'qst' and extension ~= 'com' and extension ~= 'me' and extension ~= 'net' and extension ~= 'info' and extension ~= 'au' and extension ~= 'nz') then
+	if not extension or (extension ~= true and extension ~= '' and extension ~= 'ccml' and extension ~= 'html' and extension ~= 'php' and extension ~= 'asp' and extension ~= 'aspx' and extension ~= 'jsp' and extension ~= 'qst' and extension ~= 'tar' and extension ~= 'dia' and extension ~= 'com' and extension ~= 'me' and extension ~= 'net' and extension ~= 'info' and extension ~= 'au' and extension ~= 'nz') then
 		local downloadsFolder = '/Downloads/'
 		if OneOS then
 			downloadsFolder = '/Desktop/Documents/Downloads/'

--- a/build
+++ b/build
@@ -1639,6 +1639,12 @@ local function resolveQuestHostUrl(url)\
 	if tld == 'qst' and #hostParts == 2 then\
 		return questHost .. hostParts[1] .. components.filepath\
 	end\
+	if tld == 'tar' and #hostParts == 2 then\
+		return 'http://65.26.252.225/quest/tar/' .. hostParts[1] .. components.filepath\
+	end\
+	if tld == 'dia' and #hostParts == 2 then\
+		return 'http://65.26.252.225/quest/dia/' .. hostParts[1] .. components.filepath\
+	end\
 	return url\
 end\
 \
@@ -5980,7 +5986,7 @@ GoToURL = function(self, url, nonVerbose, noHistory, post)\
 \
 	-- TODO: 404s are counted as downloads\
 \
-	if not extension or (extension ~= true and extension ~= '' and extension ~= 'ccml' and extension ~= 'html' and extension ~= 'php' and extension ~= 'asp' and extension ~= 'aspx' and extension ~= 'jsp' and extension ~= 'qst' and extension ~= 'com' and extension ~= 'me' and extension ~= 'net' and extension ~= 'info' and extension ~= 'au' and extension ~= 'nz') then\
+	if not extension or (extension ~= true and extension ~= '' and extension ~= 'ccml' and extension ~= 'html' and extension ~= 'php' and extension ~= 'asp' and extension ~= 'aspx' and extension ~= 'jsp' and extension ~= 'qst' and extension ~= 'tar' and extension ~= 'dia' and extension ~= 'com' and extension ~= 'me' and extension ~= 'net' and extension ~= 'info' and extension ~= 'au' and extension ~= 'nz') then\
 		local downloadsFolder = '/Downloads/'\
 		if OneOS then\
 			downloadsFolder = '/Desktop/Documents/Downloads/'\

--- a/startup
+++ b/startup
@@ -308,6 +308,12 @@ local function resolveQuestHostUrl(url)
 	if tld == 'qst' and #hostParts == 2 then
 		return questHost .. hostParts[1] .. components.filepath
 	end
+	if tld == 'tar' and #hostParts == 2 then
+		return "http://65.26.252.225/quest/tar/" .. hostParts[1] .. components.filepath
+	end
+	if tld == 'dia' and #hostParts == 2 then
+		return "http://65.26.252.225/quest/dia/" .. hostParts[1] .. components.filepath
+	end
 	return url
 end
 


### PR DESCRIPTION
![dot-tar.tar](http://i.imgur.com/L5n6hpc.png)

Adding .tar to provide more functionality to websites (PHP/MySQL) than host.qst can provide, and .dia as a TLD that can only be acquired with proof-of-work (ensuring that only dedicated individuals can register them).

I have a few websites already online. I encourage you to check out whois.tar:
![whois.tar](http://i.imgur.com/KXpn6EM.png)
Data for .qst domains is limited. There are 225 registered as of this pull request, but I can only see their names and content, no dates or clients. You should make that info visible somehow. :)

.tar may be beneficial in other ways. Registration and uploading would take place outside of the game, and the sites would exist on a separate server to distribute the usage. Not to mention that if someone wants a name that is taken as a .qst, they can check if it is available in .tar form.

I have thoroughly tested this, and it works pretty well. ;)
As for why I chose .tar; I couldn't really think of anything else :P
